### PR TITLE
 Rename get_citation to get_all to clarify function and to match other methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,3 @@ Projektin Backlogi:
 
 
 
-

--- a/src/repositories/citation_repository.py
+++ b/src/repositories/citation_repository.py
@@ -49,7 +49,7 @@ class CitationRepository:
         except Exception:
             return None
 
-    def get_citation(self) -> list:
+    def get_all(self) -> list:
         """Returns all citations
 
         Returns:

--- a/src/services/citation_service.py
+++ b/src/services/citation_service.py
@@ -87,7 +87,7 @@ class CitationService:
 
     def get_all(self):
         """ Return list of all citations """
-        return self.repo.get_citation()
+        return self.repo.get_all()
 
     def get_last(self):
         """ Return last element of citations


### PR DESCRIPTION
Other simple methods in citation_service match their citation_repository implementations, so I renamed this method to follow that. The new name also more clearly communicates what the exactly method does.